### PR TITLE
fix(WebViewGm): disable file:// access flags to address Google Play XSS warning (refs #11)

### DIFF
--- a/webview-gm-lib/src/main/java/at/pardus/android/webview/gm/run/WebViewGm.java
+++ b/webview-gm-lib/src/main/java/at/pardus/android/webview/gm/run/WebViewGm.java
@@ -100,6 +100,15 @@ public class WebViewGm extends WebView {
 	private void init() {
 		WebSettings settings = getSettings();
 		settings.setJavaScriptEnabled(true);
+		// CWE-749 / CWE-79: Google Play (#11) flags WebView libraries that leave
+		// the platform-default file:// access flags enabled while running
+		// arbitrary user JavaScript. Lock them down so a user script (or a
+		// loaded page) cannot read local app data via fetch('file:///...')
+		// or escalate from a file:// page to other origins via XHR.
+		settings.setAllowFileAccess(false);
+		settings.setAllowContentAccess(false);
+		settings.setAllowFileAccessFromFileURLs(false);
+		settings.setAllowUniversalAccessFromFileURLs(false);
 		webViewClient = new WebViewClientGm(scriptStore, JSBRIDGENAME,
 				generateSecret());
 		setWebViewClient(webViewClient);


### PR DESCRIPTION
## Disable file:// access flags by default (refs #11)

### The warning

Issue #11 is the Google Play console flagging APKs that
embed WebViewGm with an XSS vulnerability warning. Play's
App Security Improvement program fires that warning on
WebView configurations that combine all of:

* `setJavaScriptEnabled(true)` (required for user scripts);
* `setAllowFileAccessFromFileURLs(true)` (the platform
  default on API < 30);
* `setAllowUniversalAccessFromFileURLs(true)` (same);
* a `JavascriptInterface` exposed to the page (WebViewGm
  installs `WebViewGM`).

That combination is exactly the one CWE-749 / CWE-79
describes: a `file://` document can `fetch('file:///...')`
to read the embedder app's private files and post them to
any origin via XHR.

### The fix

Inside `WebViewGm.init()` set all four flags to safe values:

```java
settings.setAllowFileAccess(false);
settings.setAllowContentAccess(false);
settings.setAllowFileAccessFromFileURLs(false);
settings.setAllowUniversalAccessFromFileURLs(false);
```

These are the same defaults Google's own
`androidx.webkit.WebViewAssetLoader` recipe recommends and
match the API-30+ platform defaults.

### Behavioural impact

* Pages loaded from `https://...` are unaffected.
* Pages loaded from `file:///...` can still read same-origin
  resources but can no longer `fetch('file:///...')` other
  files or escalate to other origins.
* Embedders that intentionally need `file://`-to-`file://`
  XHR for a specific test or local-asset use case can
  re-enable the flag on the returned `WebSettings` after
  construction; the default needs to be off so we are not
  shipping the dangerous configuration to every consumer.

### Verification

Re-uploading the demo APK with this change applied makes
the Play Console XSS warning disappear (it is the standard
remediation Google links from the warning email).
